### PR TITLE
rsyslog: add uci support

### DIFF
--- a/admin/rsyslog/Makefile
+++ b/admin/rsyslog/Makefile
@@ -72,6 +72,8 @@ define Package/rsyslog/install
 	$(INSTALL_CONF) ./files/rsyslog.conf $(1)/etc
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/rsyslog.init $(1)/etc/init.d/rsyslog
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/rsyslog $(1)/etc/config
 endef
 
 define Package/rsyslog/config

--- a/admin/rsyslog/files/rsyslog
+++ b/admin/rsyslog/files/rsyslog
@@ -1,0 +1,28 @@
+config syslog syslog
+    option tcp_input '0'
+    option tcp_input_port '514'
+    option udp_input '1'
+    option udp_input_port '514'
+    option default_template 'RSYSLOG_TraditionalFileFormat'
+    list modules 'imuxsock'
+    list modules 'imklog'
+
+config selector
+	option source '*.info;mail.none;authpriv.none;cron.none'
+	option destination '/var/log/messages'
+
+config selector
+    option source 'authpriv.*'
+    option destination '/var/log/secure'
+
+config selector
+    option source 'mail.*'
+    option destination '/var/log/maillog'
+
+config selector
+    option source 'cron.*'
+    option destination '/var/log/cron'
+
+config selector
+    option source 'local7.*'
+    option destination '/var/log/boot.log'

--- a/admin/rsyslog/files/rsyslog.init
+++ b/admin/rsyslog/files/rsyslog.init
@@ -5,8 +5,100 @@ START=20
 
 USE_PROCD=1
 
+UCI_CONF="rsyslog"
+CONFIG_FILE="/etc/rsyslog.conf"
+
+modules=""
+selectors=""
+forwarders=""
+
+handle_selector() {
+    local config="$1"
+    local src
+    local dst
+
+    config_get src ${config} source
+    config_get dst ${config} destination
+    if [ ${src} != "" ] && [ "$dst" != "" ]; then
+        selectors="${selectors}\n${src}\t${dst}\n"
+    fi
+}
+
+handle_forwarder() {
+    local config="$1"
+    local src
+    local target
+    local protocol
+    local port
+    local rfc
+    local opts
+
+    config_get src ${config} source
+    config_get target ${config} target
+    config_get protocol ${config} protocol "udp"
+    config_get port ${config} port "514"
+    config_get rfc ${config} rfc "3164"
+
+    if [ "$rfc" == "5424" ]; then
+        opts='Template="RSYSLOG_SyslogProtocol23Format" TCP_Framing="octet-counted"'
+    fi
+
+    if [ ${src} != "" ] && [ "${target}" != "" ]; then
+        action="action(type=\"omfwd\" target=\"$target\" port=\"$port\" protocol=\"$protocol\" $opts action.resumeRetryCount=\"100\" queue.type=\"linkedList\" queue.size=\"10000\")"
+       forwarders="${forwarders}\n${src}\t${action}\n"
+    fi
+}
+
+
+expand_config() {
+    local input_t=""
+    local input_u=""
+
+    config_load ${UCI_CONF}
+    config_list_foreach syslog modules handle_module
+    config_get_bool tcp_input syslog tcp_input
+    if [ ${tcp_input} -eq 1 ]; then
+        modules="${modules} imtcp"
+        config_get tcp_port syslog tcp_input_port
+        input_t="input(type=\"imtcp\" port=\"${tcp_port}\")"
+    fi
+
+    config_get_bool udp_input syslog udp_input
+    if [ ${udp_input} -eq 1 ]; then
+        modules="${modules} imudp"
+        config_get udp_port syslog udp_input_port
+        input_u="input(type=\"imudp\" port=\"${udp_port}\")"
+
+    fi
+    config_get template syslog default_template
+    config_foreach handle_selector selector
+    config_foreach handle_forwarder forwarder
+
+    > ${CONFIG_FILE}
+    for m in ${modules}; do
+        echo "module(load=\"${m}\")" >> ${CONFIG_FILE}
+    done
+    echo ${input_t} >> ${CONFIG_FILE}
+    echo ${input_u} >> ${CONFIG_FILE}
+    echo "\$ActionFileDefaultTemplate ${template}" >> ${CONFIG_FILE}
+    echo -e ${selectors} >> ${CONFIG_FILE}
+    echo -e ${forwarders} >> ${CONFIG_FILE}
+}
+
+handle_module() {
+    local module="$1"
+    modules="${modules} $module"
+}
+
 start_service() {
+	expand_config
 	procd_open_instance
 	procd_set_param command /usr/sbin/rsyslogd -n
 	procd_close_instance
+}
+
+
+service_triggers()
+{
+    procd_add_reload_trigger ${UCI_CONF}
 }


### PR DESCRIPTION
Maintainer: gsanchietti
Compile tested: x86, 22.03.0-rc3
Run tested: x86, 22.03.0-rc3, replaced logd with rsyslog

Description:

Support dynamic configuration with UCI.
Default rsyslog configuration is preserved and moved inside `/etc/config/rsyslog`.

Enable TCP receiver:
```
uci set rsyslog.syslog.tcp_input='1'
uci commit
/etc/init.d/rsyslog restart
```

Setup forwarding to another rsyslog:
```
uci set rsyslog.remote=forwarder
uci set rsyslog.remote.source=*.*
uci set rsyslog.remote.protocol=udp
uci set rsyslog.remote.port=10514
uci set rsyslog.remote.rfc=3164
uci set rsyslog.remote.target=192.168.122.2
uci commit
/etc/init.d/rsyslog restart
```

If `rfc` is set to `5424`, the template will be accordingly and TCP framing will be set to `octed-counted`.
Setup forwarding to promtail:
```
uci set rsyslog.promtail=forwarder
uci set rsyslog.promtail.source=*.*
uci set rsyslog.promtail.protocol=tcp
uci set rsyslog.promtail.port=10514
uci set rsyslog.promtail.rfc=5424
uci set rsyslog.promtail.target=192.168.122.2
uci commit
/etc/init.d/rsyslog restart
```